### PR TITLE
Digisam 115 finetune

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ That should not be a problem for small-scale testing, but medium- to large-scale
 these limits should be raised.
 1. Check that the local SolrCloud is running by visiting http://localhost:10007/solr/#/
 1. Upload a collection configuration to SolrCloud    
-`solr-8.2.0/bin/solr zk upconfig -z localhost:9983 -d template/ -n ds-conf`
+`solr-8.2.0/bin/solr zk upconfig -z localhost:11007 -d template/ -n ds-conf`
 1. Create a collection in SolrCloud  
 `solr-8.2.0/bin/solr create_collection -c ds -n ds-conf`
 1. Check that the collection was created by visiting 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ these limits should be raised.
 `solr-8.2.0/bin/post -p 10007 -c ds test/sample_document_1.xml`
 1. Check that the document was indexed by performing a manual search through the 
 [Solr admin web interface](http://localhost:10007/solr/#/ds/query) or with curl  
-`curl 'http://localhost:10007/solr/ds/select?wt=json&q=*:*`
+`curl 'http://localhost:10007/solr/ds/select?wt=json&q=*:*'`
 1. Stop Solr with  
 `solr-8.2.0/bin/solr stop` 
 
@@ -45,6 +45,9 @@ and
 `solr-8.2.0/bin/solr stop`  
 without losing any documents.
 
+## Search tips
+1. Search for all material geographically with [geo rectangle](https://lucene.apache.org/solr/guide/8_1/spatial-search.html#filtering-by-an-arbitrary-rectangle)  
+`curl 'http://localhost:10007/solr/ds/select?wt=json&q=location_coordinates:\[55.10,9.21+TO+58.10,11.21\]'`
 
 
 ## Fields

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ and uses the same setup files as production.
 1. Unpack it  
 `tar xzovf solr-8.2.0.tgz`
 1. Start Solr in cloud mode  
-`solr-8.2.0/bin/solr -c -m 1g`    
+`solr-8.2.0/bin/solr -c -m 1g -p 10007`    
 It will probably complain about `open file` and `max processes` limits. 
 That should not be a problem for small-scale testing, but medium- to large-scale,
 these limits should be raised.
-1. Check that the local SolrCloud is running by visiting http://localhost:8983/solr/#/
+1. Check that the local SolrCloud is running by visiting http://localhost:10007/solr/#/
 1. Upload a collection configuration to SolrCloud    
 `solr-8.2.0/bin/solr zk upconfig -z localhost:9983 -d template/ -n ds-conf`
 1. Create a collection in SolrCloud  
 `solr-8.2.0/bin/solr create_collection -c ds -n ds-conf`
 1. Check that the collection was created by visiting 
-[http://localhost:8983/solr/#/~cloud?view=graph](http://localhost:8983/solr/#/~cloud?view=graph)
+[http://localhost:10007/solr/#/~cloud?view=graph](http://localhost:10007/solr/#/~cloud?view=graph)
 1. Index a sample document  
 `solr-8.2.0/bin/post -c ds test/sample_document_1.xml`
 1. Check that the document was indexed by performing a manual search through the 
-[Solr admin web interface](http://localhost:8983/solr/#/ds/query) or with curl  
-`curl 'http://localhost:8983/solr/ds/select?wt=json&q=*:*`
+[Solr admin web interface](http://localhost:10007/solr/#/ds/query) or with curl  
+`curl 'http://localhost:10007/solr/ds/select?wt=json&q=*:*`
 1. Stop Solr with  
 `solr-8.2.0/bin/solr stop` 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ and uses the same setup files as production.
 `wget 'http://mirrors.dotsrc.org/apache/lucene/solr/8.2.0/solr-8.2.0.tgz'`
 1. Unpack it  
 `tar xzovf solr-8.2.0.tgz`
+1. Compensate for the [SOLR-13606](https://issues.apache.org/jira/browse/SOLR-13606) bug  
+`echo 'SOLR_OPTS="$SOLR_OPTS -Djava.locale.providers=JRE,SPI"' >> solr-8.2.0/bin/solr.in.sh`
 1. Start Solr in cloud mode  
 `solr-8.2.0/bin/solr -c -m 1g -p 10007`    
 It will probably complain about `open file` and `max processes` limits. 
@@ -30,7 +32,7 @@ these limits should be raised.
 1. Check that the collection was created by visiting 
 [http://localhost:10007/solr/#/~cloud?view=graph](http://localhost:10007/solr/#/~cloud?view=graph)
 1. Index a sample document  
-`solr-8.2.0/bin/post -c ds test/sample_document_1.xml`
+`solr-8.2.0/bin/post -p 10007 -c ds test/sample_document_1.xml`
 1. Check that the document was indexed by performing a manual search through the 
 [Solr admin web interface](http://localhost:10007/solr/#/ds/query) or with curl  
 `curl 'http://localhost:10007/solr/ds/select?wt=json&q=*:*`

--- a/test/sample_document_1.xml
+++ b/test/sample_document_1.xml
@@ -38,6 +38,6 @@
   <field name="language">en</field>
   <field name="location">Aarhus, Denmark</field>
   <!-- TODO: Get proper coordinates for Aarhus -->
-  <field name="location_coordinates">54,48</field>
+  <field name="location_coordinates">56.15,10.216667</field>
 </doc>
 </add>


### PR DESCRIPTION
Minor issues: The installation instructions not assigns the port `10007` to Solr (it is within the open port range on the test server) and the sample document  now has location-coordinates that matches the location-name.