### PR TITLE
Add fields for image requests

### DIFF
--- a/template/conf/schema.xml
+++ b/template/conf/schema.xml
@@ -136,6 +136,25 @@ daterange does not handle docValues - we might need two versions of datetime
     <!-- Total number of pixels in a still image or a single frame for moving image. -->
     <field name="pixels"           type="long"/>
 
+    <!-- One or more preview images if available.
+         Size and quality is not defined, but aim for something fairly
+         lightweight, i.e. < 100 KB and between 500x500 and 1000x1000 pixels.
+         For image material there will typically only be a single preview, while moving images
+         might provide more preview images. -->
+    <field name="image_preview"    type="string" multiValued="true"/>
+
+    <!-- If the material is an image, this field contains an URL to the full image at the highest
+         possible quality. If the material is not an image, this field will not be defined.
+         Hint: If available, it is recommended for the user to use the iiif-field for image requests,
+         as it offers more options. -->
+    <field name="image_full"       type="string"/>
+
+    <!-- If the material is served by an IIIF-compliant server, this is the base URL to the material on the server, e.g.
+         https://kb-images.kb.dk/DAMJP2/online_master_arkiv/non-archival/KOB/bs_kistebilleder-2/bs000007/
+         Hint: Parameters for image requests to IIIF can be found at https://iiif.io/api/image/2.1/#image-request-parameters -->
+    <field name="iiif"             type="string"/>
+    
+    
     <!-- Short and controlled form of the licence for the material. Valid entries are
          * [Creative commons hort form](https://creativecommons.org/choose/), e.g. `by-nc-sa` or `cc0`
          * `Apache License 2.0`


### PR DESCRIPTION
Turns out we need some fields for holding image-related URLs if we want to deliver images.

I am not sure if the fields are the best. I expect us to extend them at some point so that we would have fields like `sound_preview` and `moving_image_preview` as mirrors to `image_preview`.